### PR TITLE
Add a few scala implementations

### DIFF
--- a/fqcnt/Makefile
+++ b/fqcnt/Makefile
@@ -4,6 +4,8 @@ PROG=fqcnt_c1_kseq fqcnt_nim1_klib fqcnt_go1 fqcnt_rs1
 NIM=nim
 GO=go
 CARGO=cargo
+AMM=amm
+MILL=mill
 PROJECT_ROOT := $(shell realpath ../)
 
 .PHONY:all clean
@@ -26,6 +28,20 @@ fqcnt_rs1:
 .PHONY: rust
 rust: fqcnt_rs1
 	@echo "Rust binaries are in ./bin/"
+
+# Scala - amm
+# Ammnoite is required to compile and run the scala script. Please obtain from ammonite.io:
+# $ sudo sh -c '(echo "#!/usr/bin/env sh" \
+#     && curl -L https://github.com/lihaoyi/Ammonite/releases/download/2.1.4/2.13-2.1.4) > /usr/local/bin/amm \
+#     && chmod +x /usr/local/bin/amm' \
+#     && amm
+fqcnt_scala_amm_fgbio: fqcnt_scala_fgbio.sc
+	echo "java -Xmx4g -jar \$$(which $(AMM)) --no-home-predef $< \$$@" > $@ 
+	chmod 755 $@
+
+# Scala - mill: http://www.lihaoyi.com/mill/
+fqcnt_scala_jar_fgbio: scala/tools/src/com/github/biofast/FgBio.scala
+	cd scala && $(MILL) tools.localJar
 
 clean:
 	rm -fr *.dSYM $(PROG)

--- a/fqcnt/README.md
+++ b/fqcnt/README.md
@@ -19,6 +19,10 @@
 |[fqcnt\_py4x\_bpitr.py](fqcnt_py4x_bpitr.py)  |Python    |[BioPython][bp]             | 37.9| 18.1|FastqGeneralIterator|
 |[fqcnt\_py2\_rfq.py](fqcnt_py2_rfq.py)        |Python    |                            | 42.7| 19.1|partial kseq.h port|
 |[fqcnt\_py5x\_bp.py](fqcnt_py5x_bp.py)        |Python    |[BioPython][bp]             |135.8|107.1|SeqIO.parse|
+|[fqcnt\_scala\_fgbio.sc](fqcnt_scala_fgbio.sc) |Scala/Ammonite|[fgbio][fgbio],[ammonite][ammonite]|TBD|TBD|FastqSource|
+|[fqcnt\_scala\_fgbio.sc](fqcnt_scala_fgbio.sc) |Scala/Ammnoite|[commons.io][commons.io][ammonite][ammonite]|TBD|TBD|Io.readlines|
+|[FgBio.scala](scala/tools//src/com/github/biofast/FgBio.scala) |Scala/JAR     |[fgbio][fgbio]             |TBD|TBD|FastqSource|
+|[FgBio.scala](scala/tools//src/com/github/biofast/FgBio.scala) |Scala/JAR     |[commons.io][commons.io]    |TBD|TBD|Io.readlines|
 
 * Crystal, Nim, Julia and Javascript use an algorithm very similar to
   [kseq.h](../lib/kseq.h). LuaJIT and the second Python script (py2) are
@@ -28,10 +32,13 @@
 * Julia takes ~11 seconds to compile the Fastx.jl implementation. The numbers
   in the table exclude this startup time.
 
-* External libraries: biopython-1.76, pyfastx-0.6.10, mappy-2.17 and
-  Fastx.jl-1.0.0.
+* Scala takes ~TBD seconds to compile the `fqcnt_scala_fgbio.sc` implementation.  The numbers
+  in the table exclude this startup time.
 
-* C, Crystal, Nim, Rust, Javascript, Go, Julia, LuaJIT and PyPy runs were timed by
+* External libraries: biopython-1.76, pyfastx-0.6.10, mappy-2.17,
+  Fastx.jl-1.0.0, and fgbio-1.1.0.
+
+* C, Crystal, Nim, Rust, Javascript, Go, Julia, LuaJIT, PyPy, and Scala runs were timed by
   hyperfine.
 
 [bp]: https://biopython.org/
@@ -40,3 +47,6 @@
 [pyfx]: https://github.com/lmdu/pyfastx
 [pysam]: https://pysam.readthedocs.io/en/latest/api.html
 [rust-bio]: https://github.com/rust-bio/rust-bio
+[fgbio]: http://fulcrumgenomics.github.io/fgbio/
+[commons.io]: https://javadoc.io/static/com.fulcrumgenomics/commons_2.12/1.0.0/com/fulcrumgenomics/commons/io/Io$.html#readLinesFromResource(name:String):Iterator[String]
+[ammnoite]: http://ammonite.io/

--- a/fqcnt/fqcnt_scala_fgbio.sc
+++ b/fqcnt/fqcnt_scala_fgbio.sc
@@ -1,0 +1,116 @@
+import $ivy.`com.fulcrumgenomics::fgbio:1.1.0`
+import java.nio.file.{Files, Path, Paths}
+import scala.collection.immutable
+import com.fulcrumgenomics.util.Io
+import com.fulcrumgenomics.commons.util.{LazyLogging, Logger}
+import com.fulcrumgenomics.commons.CommonsDef.{PathToFastq, SafelyClosable}
+import com.fulcrumgenomics.fastq.FastqSource
+import com.fulcrumgenomics.FgBioDef.FgBioEnum
+import enumeratum.EnumEntry
+
+/** Benchmark results */
+case class BenchmarkResults(numRecords: Long, totalBases: Long, totalQualityScores: Long)
+
+/** Trait all benchmarking implementations should extend. */
+sealed trait FastqBenchmark extends EnumEntry{
+  /** Runs the benchmark. */
+  def run(in: PathToFastq): Unit = {
+    //println("*" * 80)
+    //println(f"Benchmarking: $this")
+
+    // Set the start time
+    //val startTimeMillis: Double   = System.currentTimeMillis() 
+
+    // Compute the benchmark results and print it out
+    val results: BenchmarkResults = this.execute(in)
+    println(f"${results.numRecords}\t${results.totalBases}\t${results.totalQualityScores}")
+
+    // Print elapsed time
+    //val endTimeMillis: Double  = System.currentTimeMillis() 
+    //val elapsedMillis: Double  = (endTimeMillis - startTimeMillis)
+    //val elapsedSeconds: Double = elapsedMillis / 1000
+    //println(f"Elapsed millis: $elapsedMillis%,.2fms")
+    //println(f"Elapsed seconds: $elapsedSeconds%,.2fs") 
+    //println("*" * 80)
+  }
+
+  /** The benchmark implementation all classes that extend this trait must implement.*/
+  protected def execute(in: PathToFastq): BenchmarkResults 
+}
+
+/** Enum to the various supported benchmarks implementations. */
+object FastqBenchmark extends FgBioEnum[FastqBenchmark] {
+
+  override def values: immutable.IndexedSeq[FastqBenchmark] = findValues
+
+  /** Benchmark using fgbio's [[FastqSource]]. */
+  case object FastqSourceBenchmark extends FastqBenchmark {
+    protected def execute(in: PathToFastq): BenchmarkResults = {
+      var numRecords: Long         = 0
+      var totalBases: Long         = 0
+      var totalQualityScores: Long = 0
+      val source: FastqSource      = FastqSource(in)
+
+      source.foreach { rec =>
+        numRecords += 1
+        totalBases += rec.bases.length
+        totalQualityScores += rec.quals.length
+      }
+      source.safelyClose
+
+      BenchmarkResults(
+        numRecords         = numRecords, 
+        totalBases         = totalBases,
+        totalQualityScores = totalQualityScores
+      )
+    }
+  } 
+
+  /** Benchmark using [[com.fulcrumgenomics.commons.Io.readlines()]]. */
+  case object BufferedReaderBenchmark extends FastqBenchmark {
+    protected def execute(in: PathToFastq): BenchmarkResults = {
+      var numRecords: Long         = 0
+      var totalBases: Long         = 0
+      var totalQualityScores: Long = 0
+      val source: Iterator[String] = Io.readLines(in)
+
+      while (source.hasNext) {
+        val header  = source.next()
+        val bases   = source.next()
+        val comment = source.next()
+        val quals   = source.next()
+
+        require(header.nonEmpty && header.head == '@', "Bug: header line")
+        require(comment.nonEmpty && comment.head == '+', "Bug: comment line")
+        numRecords += 1
+        totalBases += bases.length
+        totalQualityScores += quals.length
+      }
+
+      BenchmarkResults(
+        numRecords         = numRecords, 
+        totalBases         = totalBases,
+        totalQualityScores = totalQualityScores
+      )
+    }
+  } 
+}
+
+/** Implicit to allow the type [[Path]] to be parsed on the command line. */
+implicit val pathRead: scopt.Read[Path] = scopt.Read.reads(path => Paths.get(path))
+
+/** Implicit to allow the type [[FastqBenchmark]] to be parsed on the command line. */
+implicit val benchmarkRead: scopt.Read[FastqBenchmark] = scopt.Read.reads(name => FastqBenchmark(name))
+
+/** The main method. */
+@doc("Scala biofast benchmarking")
+@main
+def main(
+  in: PathToFastq @doc("The input FASTQ.") = Io.StdIn,
+  benchmark: FastqBenchmark @doc("The FASTQ benchmarks to run") =  FastqBenchmark.FastqSourceBenchmark,
+  dryrun: Boolean @doc("True to skip benchmarking") = false
+): Unit = {
+  if (!dryrun) {
+    benchmark.run(in=in)
+  }
+}

--- a/fqcnt/scala/build.sc
+++ b/fqcnt/scala/build.sc
@@ -1,0 +1,140 @@
+import java.util.jar.Attributes.Name.{IMPLEMENTATION_VERSION => ImplementationVersion}
+
+import ammonite.ops._
+import coursier.maven.MavenRepository
+import mill._
+import mill.api.Loose
+import mill.define.{Input, Target}
+import mill.scalalib._
+import mill.scalalib.publish.{License, PomSettings, _}
+import $ivy.`com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION`
+import mill.contrib.scoverage.ScoverageModule
+
+import scala.util.{Failure, Success, Try}
+
+private val fgbioCommonsVersion = "1.1.0-28cd47e-SNAPSHOT"
+private val fgbioVersion        = "1.2.0-4798fd1-SNAPSHOT"
+
+private val excludeOrg = Seq("com.google.cloud.genomics", "gov.nih.nlm.ncbi", "org.apache.ant",  "org.testng")
+
+
+/** The ScalaTest settings. */
+trait ScalaTest extends TestModule {
+
+  /** Ivy dependencies. */
+  override def ivyDeps = Agg(
+    ivy"org.scalatest::scalatest::3.0.7".excludeOrg(organizations="org.junit"),
+    ivy"org.scalamock::scalamock::4.4.0"
+  )
+
+  /** Test frameworks. */
+  override def testFrameworks: Target[Seq[String]] = Seq("org.scalatest.tools.Framework")
+
+  /** Run a single test with `scalatest`. */
+  def testOne(args: String*): mill.define.Command[Unit] = T.command {
+    super.runMain(mainClass = "org.scalatest.run", args: _*)
+  }
+}
+
+/** A base trait for versioning modules. */
+trait ReleaseModule extends ScalaModule {
+
+  /** Execute Git arguments and return the standard output. */
+  private def git(args: String*): String = %%("git", args)(pwd).out.string.trim
+
+  /** Get the commit hash at the HEAD of this branch. */
+  private def gitHead: String = git("rev-parse", "HEAD")
+
+  /** Get the commit shorthash at the HEAD of this branch .*/
+  private def shortHash: String = gitHead.take(7)
+
+  /** The current tag of the currently checked out commit, if any. */
+  private def currentTag: Try[String] = Try(git("describe", "--exact-match", "--tags", "--always", gitHead))
+
+  /** The hash of the last tagged commit. */
+  private def hashOfLastTag: Try[String] = Try(git("rev-list", "--tags", "--max-count=1"))
+
+  /** The last tag of the currently checked out branch, if any. */
+  private def lastTag: Try[String] = hashOfLastTag match {
+    case Success(hash) => Try(git("describe", "--abbrev=0", "--tags", "--always", hash))
+    case Failure(e)    => Failure(e)
+  }
+
+  /** If the Git repository is left in a dirty state. */
+  private def dirty: Boolean = git("status", "--porcelain").nonEmpty
+
+  /** The implementation version. */
+  def implementationVersion: Input[String] = T.input {
+    val prefix: String = (currentTag, lastTag) match {
+      case (Success(_currentTag), _)       => _currentTag
+      case (Failure(_), Success(_lastTag)) => _lastTag + "-" + shortHash
+      case (_, _)                          => shortHash
+    }
+    prefix + (if (dirty) "-dirty" else "")
+  }
+
+  /** The version string `Target`. */
+  def version = T { println(implementationVersion()) }
+
+  /** The JAR manifest. */
+  override def manifest = T { super.manifest().add(ImplementationVersion.toString -> implementationVersion()) }
+
+  /** The publish version. Currently set to the implementation version. */
+  def publishVersion: T[String] = implementationVersion
+
+  /** POM Settings. */
+  def pomSettings: T[PomSettings] = PomSettings(
+    description    = "TODO",
+    organization   = "com.github.nh13",
+    url            = "https://github.com/nh13/biofast",
+    licenses       = Seq(License.MIT),
+    versionControl = VersionControl.github(owner = "nh13", repo = "biofast"),
+    developers     = Seq(Developer("nh13", "Nils Homer", "https://github.com/nh13"))
+  )
+}
+
+/** The common module mixin for all of our projects. */
+trait CommonModule extends ScalaModule with ReleaseModule with ScoverageModule {
+  def scalaVersion     = "2.13.1"
+  def scoverageVersion = "1.4.0"
+
+  override def repositories: Seq[coursier.Repository] = super.repositories ++ Seq(
+    MavenRepository("https://oss.sonatype.org/content/repositories/public"),
+    MavenRepository("https://oss.sonatype.org/content/repositories/snapshots"),
+    MavenRepository("https://jcenter.bintray.com/"),
+    MavenRepository("https://artifactory.broadinstitute.org/artifactory/libs-snapshot/")
+  )
+
+  def localJar(assembly: PathRef, jarName: String): Unit = {
+    mkdir(pwd / 'jars)
+    cp.over(assembly.path, pwd / 'jars / jarName)
+  }
+
+  def testModulesDeps: Seq[TestModule] = Nil
+
+  object test extends Tests with ScalaTest with ScoverageTests {
+    override def moduleDeps: Seq[JavaModule]        = super.moduleDeps ++ testModulesDeps
+    override def ivyDeps: Target[Loose.Agg[Dep]]    = super.ivyDeps()
+    override def runIvyDeps: Target[Loose.Agg[Dep]] = super.runIvyDeps()
+  }
+}
+
+/** The commons project. */
+object tools extends CommonModule {
+
+  /** The artifact name. */
+  override def artifactName: T[String] = "fqcnt_scala_fgbio"
+
+  /** Scala compiler options. */
+  override def scalacOptions: Target[Seq[String]] = T { Seq("-target:jvm-1.8", "-deprecation", "-feature") }
+
+  /** Ivy dependencies. */
+  override def ivyDeps = Agg(
+    ivy"com.fulcrumgenomics::commons::$fgbioCommonsVersion",
+    ivy"com.fulcrumgenomics::fgbio::$fgbioVersion".excludeOrg(organizations=excludeOrg: _*),
+    ivy"org.slf4j:slf4j-nop:1.7.6"  // For logging silence: https://www.slf4j.org/codes.html#StaticLoggerBinder
+  )
+
+  /** Build a JAR file from the tools project. */
+  def localJar = T { super.localJar(assembly(), jarName = "fqcnt_scala_fgbio.jar") }
+}

--- a/fqcnt/scala/tools/src/com/github/biofast/FgBio.scala
+++ b/fqcnt/scala/tools/src/com/github/biofast/FgBio.scala
@@ -1,0 +1,109 @@
+import java.nio.file.{Files, Path, Paths}
+import scala.collection.immutable
+import com.fulcrumgenomics.commons.io.Io
+import com.fulcrumgenomics.commons.util.{LazyLogging, Logger}
+import com.fulcrumgenomics.commons.CommonsDef.{PathToFastq, SafelyClosable}
+import com.fulcrumgenomics.fastq.FastqSource
+import com.fulcrumgenomics.FgBioDef.FgBioEnum
+import enumeratum.EnumEntry
+
+/** Benchmark results */
+case class BenchmarkResults(numRecords: Long, totalBases: Long, totalQualityScores: Long)
+
+/** Trait all benchmarking implementations should extend. */
+sealed trait FastqBenchmark extends EnumEntry{
+  /** Runs the benchmark. */
+  def run(in: PathToFastq): Unit = {
+    //println("*" * 80)
+    //println(f"Benchmarking: $this")
+
+    // Set the start time
+    //val startTimeMillis: Double   = System.currentTimeMillis() 
+
+    // Compute the benchmark results and print it out
+    val results: BenchmarkResults = this.execute(in)
+    println(f"${results.numRecords}\t${results.totalBases}\t${results.totalQualityScores}")
+
+    // Print elapsed time
+    //val endTimeMillis: Double  = System.currentTimeMillis() 
+    //val elapsedMillis: Double  = (endTimeMillis - startTimeMillis)
+    //val elapsedSeconds: Double = elapsedMillis / 1000
+    //println(f"Elapsed millis: $elapsedMillis%,.2fms")
+    //println(f"Elapsed seconds: $elapsedSeconds%,.2fs") 
+    //println("*" * 80)
+  }
+
+  /** The benchmark implementation all classes that extend this trait must implement.*/
+  protected def execute(in: PathToFastq): BenchmarkResults 
+}
+
+/** Enum to the various supported benchmarks implementations. */
+object FastqBenchmark extends FgBioEnum[FastqBenchmark] {
+
+  override def values: immutable.IndexedSeq[FastqBenchmark] = findValues
+
+  /** Benchmark using fgbio's [[FastqSource]]. */
+  case object FastqSourceBenchmark extends FastqBenchmark {
+    protected def execute(in: PathToFastq): BenchmarkResults = {
+      var numRecords: Long         = 0
+      var totalBases: Long         = 0
+      var totalQualityScores: Long = 0
+      val source: FastqSource      = FastqSource(in)
+
+      source.foreach { rec =>
+        numRecords += 1
+        totalBases += rec.bases.length
+        totalQualityScores += rec.quals.length
+      }
+      source.safelyClose
+
+      BenchmarkResults(
+        numRecords         = numRecords, 
+        totalBases         = totalBases,
+        totalQualityScores = totalQualityScores
+      )
+    }
+  } 
+
+  /** Benchmark using [[com.fulcrumgenomics.commons.Io.readlines()]]. */
+  case object BufferedReaderBenchmark extends FastqBenchmark {
+    protected def execute(in: PathToFastq): BenchmarkResults = {
+      var numRecords: Long         = 0
+      var totalBases: Long         = 0
+      var totalQualityScores: Long = 0
+      val source: Iterator[String] = Io.readLines(in)
+
+      while (source.hasNext) {
+        val header  = source.next()
+        val bases   = source.next()
+        val comment = source.next()
+        val quals   = source.next()
+
+        require(header.nonEmpty && header.head == '@', "Bug: header line")
+        require(comment.nonEmpty && comment.head == '+', "Bug: comment line")
+        numRecords += 1
+        totalBases += bases.length
+        totalQualityScores += quals.length
+      }
+
+      BenchmarkResults(
+        numRecords         = numRecords, 
+        totalBases         = totalBases,
+        totalQualityScores = totalQualityScores
+      )
+    }
+  } 
+}
+
+/** The main method. */
+object FgBio {
+  def main(args: Array[String]): Unit = {
+    require(args.length > 0, "Usage: <in.fq> <benchmark-to-run> [<dry-run>]")
+    val in: PathToFastq           = Paths.get(args(0))
+    val benchmark: FastqBenchmark = FastqBenchmark(args(1))
+    val dryrun: Boolean           = args.length > 2 && args(2) == "true"
+    if (!dryrun) {
+      benchmark.run(in=in)
+    }
+  }
+}


### PR DESCRIPTION
## Added

* A [`fgbio`](http://fulcrumgenomics.github.io/fgbio/) implementation for Scala
* A [`commons`](https://github.com/fulcrumgenomics/commons/) implementation for Scala

## Changed

* `Makefile` now has a target `fqcnt_scala_fgbio` for building a wrapper script for running the Scala-script with the [Ammonite REPL](http://ammonite.io/).

## Benchmark

I ran the C, Go, Rust, Pysam, pyfastx, and Scala implementations with hyperfine as follows (similar to https://github.com/lh3/biofast/pull/3).

```bash
function benchmark () 
{
  local fq=$1;
  local output=results.$(basename $fq .fq).md
  local dryrun=${2:-"false"}

  pushd fqcnt
  C_CMD="./fqcnt_c1_kseq $fq"
  RS_CMD="./bin/fqcnt_rustbio $fq"
  GO_CMD="./fqcnt_go1 $fq"
  PYFASTX_CMD="./fqcnt_py6x_pyfx.py $fq"
  PYSAM_CMD="./fqcnt_py7x_pysam.py $fq"
  SCALA_FGBIO_AMM_CMD="./fqcnt_scala_amm_fgbio --in $fq --benchmark FastqSourceBenchmark"
  SCALA_COMMONS_AMM_CMD="./fqcnt_scala_amm_fgbio --in $fq --benchmark BufferedReaderBenchmark"
  SCALA_FGBIO_JAR_CMD="java -Xmx2g -jar scala/jars/fqcnt_scala_fgbio.jar $fq FastqSourceBenchmark"
  SCALA_COMMONS_JAR_CMD="java -Xmx2g -jar scala/jars/fqcnt_scala_fgbio.jar $fq BufferedReaderBenchmark"
  if [[ "$dryrun" == "true" ]]; then
	  SCALA_FGBIO_AMM_CMD="$SCALA_FGBIO_AMM_CMD --dryrun true"
	  SCALA_COMMONS_AMM_CMD="$SCALA_COMMONS_AMM_CMD --dryrun true"
	  SCALA_FGBIO_JAR_CMD="$SCALA_FGBIO_JAR_CMD true"
	  SCALA_COMMONS_JAR_CMD="$SCALA_COMMONS_JAR_CMD true"
  fi
  hyperfine --warmup 3 --runs 10 --export-markdown $output \
    "$C_CMD" "$RS_CMD" "$GO_CMD" "$PYFASTX_CMD" "$PYSAM_CMD" "$SCALA_FGBIO_AMM_CMD" "$SCALA_FGBIO_JAR_CMD" "$SCALA_COMMONS_AMM_CMD" "$SCALA_COMMONS_JAR_CMD"
  popd
}

benchmark ../data/one_record.fq "true"
benchmark ../data/M_abscessus_HiSeq.fq 
benchmark ../data/M_abscessus_HiSeq.fq.gz 
```

I also ran on a single-record FASTQ

### Startup/shutdown time

I ran the implementations on a single record (the first one) FASTQ.  For most implementations, the startup/shutdown time are negligible, but for the Scala implementations, it is not.  As expected, using the Ammonite REPL has a larger start up cost than a pre-built assembly JAR.  

So the discussion in the benchmarks is if we should exclude start-up/shutdown costs, which are fixed.  If we want a tool that can start up, execute, and execute in the smallest absolute time, then include it.  If we want to expect performance when the tool will run for a minute to hours, then we should remove it.  I have not removed the time in the results later.

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./fqcnt_c1_kseq ../data/one_record.fq` | 2.0 ± 0.2 | 1.7 | 2.4 | 1.00 |
| `./bin/fqcnt_rustbio ../data/one_record.fq` | 2.7 ± 0.6 | 2.1 | 3.5 | 1.40 ± 0.33 |
| `./fqcnt_go1 ../data/one_record.fq` | 3.4 ± 0.6 | 2.8 | 4.4 | 1.74 ± 0.38 |
| `./fqcnt_py6x_pyfx.py ../data/one_record.fq` | 33.8 ± 3.3 | 29.9 | 37.4 | 17.22 ± 2.69 |
| `./fqcnt_py7x_pysam.py ../data/one_record.fq` | 68.9 ± 6.2 | 61.0 | 81.0 | 35.13 ± 5.36 |
| `./fqcnt_scala_amm_fgbio --in ../data/one_record.fq --benchmark FastqSourceBenchmark --dryrun true` | 770.6 ± 10.2 | 749.7 | 789.0 | 393.04 ± 48.60 |
| `java -Xmx2g -jar scala/jars/fqcnt_scala_fgbio.jar ../data/one_record.fq FastqSourceBenchmark true` | 261.2 ± 4.2 | 255.2 | 267.6 | 133.25 ± 16.52 |
| `./fqcnt_scala_amm_fgbio --in ../data/one_record.fq --benchmark BufferedReaderBenchmark --dryrun true` | 753.8 ± 5.9 | 746.2 | 762.4 | 384.50 ± 47.36 |
| `java -Xmx2g -jar scala/jars/fqcnt_scala_fgbio.jar ../data/one_record.fq BufferedReaderBenchmark true` | 261.3 ± 3.5 | 255.1 | 264.7 | 133.27 ± 16.48 |

### Non-compressed

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./fqcnt_c1_kseq ../data/M_abscessus_HiSeq.fq` | 746.7 ± 24.3 | 706.8 | 795.6 | 1.00 |
| `./bin/fqcnt_rustbio ../data/M_abscessus_HiSeq.fq` | 2802.3 ± 37.6 | 2753.3 | 2869.4 | 3.75 ± 0.13 |
| `./fqcnt_go1 ../data/M_abscessus_HiSeq.fq` | 1370.8 ± 23.8 | 1340.7 | 1413.2 | 1.84 ± 0.07 |
| `./fqcnt_py6x_pyfx.py ../data/M_abscessus_HiSeq.fq` | 6241.7 ± 396.2 | 5770.5 | 6773.8 | 8.36 ± 0.60 |
| `./fqcnt_py7x_pysam.py ../data/M_abscessus_HiSeq.fq` | 8303.4 ± 79.5 | 8195.9 | 8397.8 | 11.12 ± 0.38 |
| `./fqcnt_scala_amm_fgbio --in ../data/M_abscessus_HiSeq.fq --benchmark FastqSourceBenchmark` | 3826.4 ± 99.4 | 3763.2 | 4101.0 | 5.12 ± 0.21 |
| `java -Xmx2g -jar scala/jars/fqcnt_scala_fgbio.jar ../data/M_abscessus_HiSeq.fq FastqSourceBenchmark` | 3366.9 ± 111.6 | 3211.2 | 3544.1 | 4.51 ± 0.21 |
| `./fqcnt_scala_amm_fgbio --in ../data/M_abscessus_HiSeq.fq --benchmark BufferedReaderBenchmark` | 3178.7 ± 95.1 | 3038.0 | 3338.3 | 4.26 ± 0.19 |
| `java -Xmx2g -jar scala/jars/fqcnt_scala_fgbio.jar ../data/M_abscessus_HiSeq.fq BufferedReaderBenchmark` | 2563.5 ± 67.3 | 2437.5 | 2698.7 | 3.43 ± 0.14 |

### Compressed

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `./fqcnt_c1_kseq ../data/M_abscessus_HiSeq.fq.gz` | 5.109 ± 0.136 | 4.841 | 5.293 | 1.00 |
| `./bin/fqcnt_rustbio ../data/M_abscessus_HiSeq.fq.gz` | 7.853 ± 0.058 | 7.740 | 7.917 | 1.54 ± 0.04 |
| `./fqcnt_go1 ../data/M_abscessus_HiSeq.fq.gz` | 10.498 ± 0.050 | 10.425 | 10.596 | 2.05 ± 0.06 |
| `./fqcnt_py6x_pyfx.py ../data/M_abscessus_HiSeq.fq.gz` | 9.881 ± 0.088 | 9.711 | 9.989 | 1.93 ± 0.05 |
| `./fqcnt_py7x_pysam.py ../data/M_abscessus_HiSeq.fq.gz` | 12.492 ± 0.138 | 12.332 | 12.815 | 2.45 ± 0.07 |
| `./fqcnt_scala_amm_fgbio --in ../data/M_abscessus_HiSeq.fq.gz --benchmark FastqSourceBenchmark` | 7.761 ± 0.075 | 7.692 | 7.962 | 1.52 ± 0.04 |
| `java -Xmx2g -jar scala/jars/fqcnt_scala_fgbio.jar ../data/M_abscessus_HiSeq.fq.gz FastqSourceBenchmark` | 7.610 ± 0.242 | 7.377 | 8.108 | 1.49 ± 0.06 |
| `./fqcnt_scala_amm_fgbio --in ../data/M_abscessus_HiSeq.fq.gz --benchmark BufferedReaderBenchmark` | 7.092 ± 0.058 | 7.005 | 7.146 | 1.39 ± 0.04 |
| `java -Xmx2g -jar scala/jars/fqcnt_scala_fgbio.jar ../data/M_abscessus_HiSeq.fq.gz BufferedReaderBenchmark` | 7.160 ± 0.206 | 6.853 | 7.454 | 1.40 ± 0.05 |

Notes:
* We may achieve better inflation time using the [intel inflater](https://github.com/Intel-HLS/GKL) (already integrated in fgbio via htsjdk)

